### PR TITLE
add: #5 Start projects

### DIFF
--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -8,7 +8,7 @@ class Api::ProjectsController < ApplicationController
   end
 
   def update
-    @project = current_user.projects.find(params[:id])
+    @project = current_project
     @project.update! update_project_params
   rescue ActiveRecord::RecordNotFound
     render_error 'Project cannot be found', :not_found
@@ -31,7 +31,24 @@ class Api::ProjectsController < ApplicationController
     render_error 'Project cannot be found', :not_found
   end
 
+  def start
+    @project = current_project
+    unless @project.started?
+      @project.start_now! due_at_param
+    else
+      render_error 'Project has already been started'
+    end
+  rescue ActiveRecord::RecordNotFound
+    render_error 'Project cannot be found', :not_found
+  rescue ActionController::ParameterMissing, ActiveRecord::RecordInvalid => error
+    render_error error.message
+  end
+
 private
+
+  def current_project
+    current_user.projects.find(params[:id])
+  end
 
   def create_project_params
     params.require(:project).permit(:name).tap do |project_params|
@@ -41,6 +58,13 @@ private
 
   def update_project_params
     params.require(:project).permit(:name, :description)
+  end
+
+  def due_at_param
+    due_at_timestamp = params.require(:project).permit(:due_at).tap do |project_params|
+      project_params.require(:due_at)
+    end[:due_at].to_i
+    Time.at(due_at_timestamp).utc.to_datetime
   end
 
 end

--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -47,7 +47,7 @@ class Api::ProjectsController < ApplicationController
 private
 
   def current_project
-    current_user.projects.find(params[:id])
+    @current_project ||= current_user.projects.find(params[:id])
   end
 
   def create_project_params
@@ -57,7 +57,9 @@ private
   end
 
   def update_project_params
-    params.require(:project).permit(:name, :description)
+    update_params = params.require(:project).permit(:name, :description)
+    update_params[:due_at] = Time.at(params[:project][:due_at].to_i).utc.to_datetime if current_project.started?
+    update_params
   end
 
   def due_at_param

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -16,6 +16,12 @@ class Project < ApplicationRecord
     started_at.present?
   end
 
+  def in_progress?
+    return false unless started?
+    now = DateTime.now
+    started_at <= now && now <= due_at
+  end
+
   def start_now!(due_at)
     if user.projects.in_progress.count >= 3
       errors.add :base, 'User cannot have more than 3 started projects'

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,7 +1,36 @@
 class Project < ApplicationRecord
+
   belongs_to :user
 
   validates :user, :name, presence: true
   validates :name, uniqueness: { scope: :user, message: 'should be unique per user' }
   validates :name, format: { with: /\A[a-z]{1}([a-z0-9_\-]{1,})*[a-z]{1}\z/, message: 'must begin and end by lowercase letters, contain only lowercase letters, numbers, underscore and hiphen, contain at least two characters' }
+  validate :due_at_not_before_started_at
+
+  scope :in_progress, -> {
+    today = DateTime.now
+    where('started_at <= ? and ? <= due_at', today, today)
+  }
+
+  def started?
+    started_at.present?
+  end
+
+  def start_now!(due_at)
+    if user.projects.in_progress.count >= 3
+      errors.add :base, 'User cannot have more than 3 started projects'
+      raise ActiveRecord::RecordInvalid.new(self)
+    end
+    update! started_at: DateTime.now, due_at: due_at
+  end
+
+private
+
+  def due_at_not_before_started_at
+    return if due_at.nil? || started_at.nil?
+    if due_at < started_at
+      errors.add :due_at, 'cannot be set before started_at'
+    end
+  end
+
 end

--- a/app/views/api/projects/_project.jbuilder
+++ b/app/views/api/projects/_project.jbuilder
@@ -1,1 +1,3 @@
 json.extract! project, :id, :name, :user_id, :description
+json.started_at project.started_at.to_i
+json.due_at project.due_at.to_i

--- a/app/views/api/projects/_project.jbuilder
+++ b/app/views/api/projects/_project.jbuilder
@@ -1,3 +1,4 @@
 json.extract! project, :id, :name, :user_id, :description
 json.started_at project.started_at.to_i
 json.due_at project.due_at.to_i
+json.is_in_progress project.in_progress?

--- a/app/views/api/projects/start.jbuilder
+++ b/app/views/api/projects/start.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'api/projects/project', project: @project

--- a/client/src/api/projects.js
+++ b/client/src/api/projects.js
@@ -17,4 +17,13 @@ export default {
   update (project, payload) {
     return patch(`/api/projects/${project.id}`, payload)
   },
+
+  start (project, dueAt) {
+    const payload = {
+      project: {
+        dueAt,
+      },
+    }
+    return post(`/api/projects/${project.id}/start`, payload)
+  },
 }

--- a/client/src/components/forms/EditProject.vue
+++ b/client/src/components/forms/EditProject.vue
@@ -8,6 +8,10 @@
       <text-field id="name" v-model="name" pattern="[a-z]{1}([a-z0-9_\-]{1,})*[a-z]{1}" required />
     </form-group>
 
+    <form-group v-if="project.isStarted" label="Due on" target="due-at" required>
+      <date-field id="due-at" v-model="dueAt" required />
+    </form-group>
+
     <form-group label="Description" target="description">
       <text-field id="description" v-model="description" multiplelines />
     </form-group>
@@ -34,6 +38,7 @@
       return {
         name: this.project.name,
         description: this.project.description,
+        dueAt: this.project.dueAt,
         error: '',
       }
     },
@@ -45,6 +50,7 @@
             project: this.project,
             name: this.name,
             description: this.description,
+            dueAt: this.dueAt,
           })
           .then(this.onSuccess)
           .catch((error) => {

--- a/client/src/components/forms/StartProject.vue
+++ b/client/src/components/forms/StartProject.vue
@@ -1,0 +1,57 @@
+<template>
+  <form @submit.prevent="start">
+    <div v-if="error">
+      {{ error }}
+    </div>
+
+    <form-group label="Name">
+      <static-field :value="project.name" />
+    </form-group>
+
+    <form-group label="Due on" target="due-at">
+      <date-field id="due-at" v-model="dueAt" />
+    </form-group>
+
+    <form-group actions>
+      <btn submit>Start it now</btn>
+      <btn type="cancel" @click="onCancel">Cancel</btn>
+    </form-group>
+  </form>
+</template>
+
+<script>
+  import moment from 'moment'
+
+  export default {
+
+    name: 'start-project-form',
+
+    props: {
+      'project': { type: Object, required: true },
+      'onSuccess': { type: Function, required: true },
+      'onCancel': { type: Function, required: true },
+    },
+
+    data () {
+      return {
+        dueAt: moment().add(1, 'month').unix(),
+        error: '',
+      }
+    },
+
+    methods: {
+      start () {
+        this.$store
+          .dispatch('projects/start', {
+            project: this.project,
+            dueAt: this.dueAt,
+          })
+          .then(this.onSuccess)
+          .catch((error) => {
+            this.error = error.data.message
+          })
+      },
+    },
+
+  }
+</script>

--- a/client/src/components/layout/AppHeader.vue
+++ b/client/src/components/layout/AppHeader.vue
@@ -34,6 +34,7 @@ export default {
 <style>
 
   .app-header {
+    margin-bottom: 10px;
     padding: 1rem 1rem;
 
     background-color: #0080b0;

--- a/client/src/components/pages/Dashboard.vue
+++ b/client/src/components/pages/Dashboard.vue
@@ -5,8 +5,17 @@
       Follow its instructions to be able to access your projects later.
     </p>
 
-    <list-item v-for="project in projects">
-      <router-link :to="project.urlShow">{{ project.name }}</router-link>
+    <container row>
+      <card v-for="project in inProgressProjects" :title="project.name" :to="project.urlShow">
+        Due on <b>{{ project.dueAtLabel }}</b>
+      </card>
+    </container>
+
+    <list-item v-for="project in notInProgressProjects">
+      <router-link :to="project.urlShow">
+        {{ project.name }}
+        <span v-if="project.isFinished">(finished)</span>
+      </router-link>
     </list-item>
 
     <btn
@@ -41,7 +50,8 @@
     computed: {
       ...mapGetters({
         user: 'users/current',
-        projects: 'projects/list',
+        inProgressProjects: 'projects/listInProgress',
+        notInProgressProjects: 'projects/listNotInProgress',
       }),
     },
 
@@ -58,6 +68,10 @@
 
   .dashboard-page .list-item:last-of-type {
     margin-bottom: 10px;
+  }
+
+  .dashboard-page .card {
+    width: 30%;
   }
 
 </style>

--- a/client/src/components/pages/projects/Show.vue
+++ b/client/src/components/pages/projects/Show.vue
@@ -1,6 +1,30 @@
 <template>
   <div class="project-show-page">
     <router-link :to="project.urlEdit">Edit</router-link>
+    <template v-if="!project.isStarted">
+      <router-link
+        v-if="canStartProject"
+        :to="project.urlStart"
+      >
+        Start this project
+      </router-link>
+      <span
+        v-else
+        class="disabled"
+        title="You already reached the maximum of started projects"
+      >
+        Start this project
+      </span>
+    </template>
+    <div v-else>
+      <form-group label="Started on">
+        <static-field :value="project.startedAtLabel" />
+      </form-group>
+      <form-group label="Due on">
+        <static-field :value="project.dueAtLabel" />
+      </form-group>
+    </div>
+
     <p v-if="project.description" class="project-description">{{ project.description }}</p>
     <p v-else>
       <em>Aucune description</em>
@@ -9,12 +33,20 @@
 </template>
 
 <script>
+  import { mapGetters } from 'vuex'
+
   export default {
 
     name: 'project-show-page',
 
     props: {
       'project': { type: Object, required: true },
+    },
+
+    computed: {
+      ...mapGetters({
+        canStartProject: 'projects/canStartProject',
+      }),
     },
 
   }
@@ -25,6 +57,11 @@
   .project-description {
     font-size: 1.1rem;
     white-space: pre-wrap;
+  }
+
+  .disabled {
+    color: #666;
+    cursor: not-allowed;
   }
 
 </style>

--- a/client/src/components/pages/projects/Start.vue
+++ b/client/src/components/pages/projects/Start.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="project-start-page">
+    <start-project-form
+      :project="project"
+      :onSuccess="redirectToShow"
+      :onCancel="redirectToShow"
+    ></start-project-form>
+  </div>
+</template>
+
+<script>
+  import StartProjectForm from '../../forms/StartProject'
+
+  export default {
+
+    name: 'project-start-page',
+
+    props: {
+      'project': { type: Object, required: true },
+    },
+
+    components: {
+      StartProjectForm,
+    },
+
+    methods: {
+      redirectToShow () {
+        this.$router.push(this.project.urlShow)
+      },
+    },
+
+  }
+</script>

--- a/client/src/router.js
+++ b/client/src/router.js
@@ -10,6 +10,7 @@ import NotFoundPage from './components/pages/NotFound'
 import ProjectLayout from './components/layout/Project'
 import ProjectShowPage from './components/pages/projects/Show'
 import ProjectEditPage from './components/pages/projects/Edit'
+import ProjectStartPage from './components/pages/projects/Start'
 
 import auth from './auth'
 
@@ -25,6 +26,7 @@ const routes = [
     children: [
       { path: '', component: ProjectShowPage, name: 'project/show' },
       { path: 'edit', component: ProjectEditPage, name: 'project/edit' },
+      { path: 'start', component: ProjectStartPage, name: 'project/start' },
     ]
   },
   { path: '*', component: NotFoundPage },

--- a/client/src/store/modules/projects.js
+++ b/client/src/store/modules/projects.js
@@ -21,6 +21,7 @@ const getters = {
         ...project,
         user,
         isStarted,
+        isFinished: isStarted && !project.isInProgress,
         startedAtLabel: isStarted ? formatDate(project.startedAt) : '',
         dueAtLabel: isStarted ? formatDate(project.dueAt) : '',
         urlShow: { name: 'project/show', params },
@@ -33,7 +34,18 @@ const getters = {
   list (state, getters) {
     return Object.keys(state.byIds)
                  .map(getters.findById)
-                 .sort((p1, p2) => p1.name.localeCompare(p2.name))
+  },
+
+  listNotInProgress (state, getters) {
+    return getters.list
+                  .filter((project) => !project.isInProgress)
+                  .sort((p1, p2) => p1.name.localeCompare(p2.name))
+  },
+
+  listInProgress (state, getters) {
+    return getters.list
+                  .filter((project) => project.isInProgress)
+                  .sort((p1, p2) => p1.dueAt > p2.dueAt)
   },
 
   current (state, getters) {

--- a/client/src/utils.js
+++ b/client/src/utils.js
@@ -1,3 +1,5 @@
+import moment from 'moment'
+
 function mapElementsById (elements, fk = 'id') {
   let byIds = {}
   elements.forEach((element) => {
@@ -7,6 +9,11 @@ function mapElementsById (elements, fk = 'id') {
   return byIds
 }
 
+function formatDate (timestamp) {
+  return moment.unix(timestamp).format('DD MMMM YYYY')
+}
+
 export {
   mapElementsById,
+  formatDate,
 }

--- a/config/initializers/json_param_key_transform.rb
+++ b/config/initializers/json_param_key_transform.rb
@@ -1,0 +1,11 @@
+# From http://stackoverflow.com/a/30557924
+# Transform JSON request param keys from JSON-conventional camelCase to
+# Rails-conventional snake_case:
+ActionDispatch::Request.parameter_parsers[:json] = -> (raw_post) {
+  # Modified from action_dispatch/http/parameters.rb
+  data = ActiveSupport::JSON.decode(raw_post)
+  data = {:_json => data} unless data.is_a?(Hash)
+
+  # Transform camelCase param keys to snake_case:
+  data.deep_transform_keys!(&:underscore)
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,10 @@ Rails.application.routes.draw do
       collection do
         get '/:user_identifier/:project_name', action: 'find', as: 'find'
       end
+
+      member do
+        post 'start'
+      end
     end
 
     get '*path', to: 'welcome#not_found'

--- a/db/migrate/20170115112412_add_dates_to_project.rb
+++ b/db/migrate/20170115112412_add_dates_to_project.rb
@@ -1,0 +1,6 @@
+class AddDatesToProject < ActiveRecord::Migration[5.0]
+  def change
+    add_column :projects, :started_at, :datetime
+    add_column :projects, :due_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170114113847) do
+ActiveRecord::Schema.define(version: 20170115112412) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,8 @@ ActiveRecord::Schema.define(version: 20170114113847) do
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false
     t.text     "description", default: ""
+    t.datetime "started_at"
+    t.datetime "due_at"
     t.index ["name", "user_id"], name: "index_projects_on_name_and_user_id", unique: true, using: :btree
     t.index ["name"], name: "index_projects_on_name", using: :btree
     t.index ["user_id"], name: "index_projects_on_user_id", using: :btree

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -12,5 +12,10 @@ FactoryGirl.define do
       started_at { 30.days.ago }
       due_at { 15.days.ago }
     end
+
+    trait :not_started do
+      started_at nil
+      due_at nil
+    end
   end
 end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -1,6 +1,16 @@
 FactoryGirl.define do
   factory :project do
-    name 'my-project'
+    sequence(:name, 'a') { |n| "my-project-#{ n }" }
     user
+
+    trait :in_progress do
+      started_at { 15.days.ago }
+      due_at { 15.days.from_now }
+    end
+
+    trait :finished do
+      started_at { 30.days.ago }
+      due_at { 15.days.ago }
+    end
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe Project, type: :model do
+
+  let(:user) { create :user }
+
+  before do
+    Timecop.freeze DateTime.new(2017)
+  end
+
+  after do
+    Timecop.return
+  end
+
+  describe 'validation' do
+    it 'does not accept due_at before started_at' do
+      project = build :project, due_at: DateTime.new(2016),
+                                started_at: DateTime.new(2017)
+      expect(project).to be_invalid
+    end
+  end
+
+  describe '#start_now!' do
+    let(:project) { create :project, :not_started, user: user }
+    let(:due_at) { DateTime.new(2018) }
+
+    context 'with less than 3 started projects' do
+      it 'succeeds' do
+        create_list :project, 2, :in_progress, user: user
+        expect { project.start_now! due_at }.not_to raise_error
+      end
+    end
+
+    context 'with finished projects' do
+      it 'succeeds' do
+        create_list :project, 3, :finished, user: user
+        expect { project.start_now! due_at }.not_to raise_error
+      end
+    end
+
+    context 'with at least 3 started projects' do
+      it 'fails' do
+        create_list :project, 3, :in_progress, user: user
+        expect { project.start_now! due_at }.to raise_error(ActiveRecord::RecordInvalid, /User cannot have more than 3 started projects/)
+      end
+    end
+  end
+
+end

--- a/spec/requests/api/projects_request_spec.rb
+++ b/spec/requests/api/projects_request_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Api::ProjectsController, type: :request do
         project = JSON.parse(response.body)
         expect(project['id']).not_to be_nil
         expect(project['name']).to eq('my-project')
+        expect(project['isInProgress']).to be false
       end
 
     end
@@ -400,6 +401,7 @@ RSpec.describe Api::ProjectsController, type: :request do
         project = JSON.parse(response.body)
         expect(project['dueAt']).to eq(1484920800)
         expect(project['startedAt']).to eq(1483228800)
+        expect(project['isInProgress']).to be true
       end
 
     end

--- a/spec/requests/api/projects_request_spec.rb
+++ b/spec/requests/api/projects_request_spec.rb
@@ -335,4 +335,148 @@ RSpec.describe Api::ProjectsController, type: :request do
 
   end
 
+  describe 'POST #start' do
+
+    let(:project) { create :project, :not_started, user: user }
+    let(:payload) { { project: { due_at: DateTime.new(2017, 01, 20, 14).to_i } } }
+
+    before do
+      Timecop.freeze DateTime.new(2017)
+    end
+
+    after do
+      Timecop.return
+    end
+
+    context 'with valid attributes' do
+
+      before do
+        post "/api/projects/#{ project.id }/start", params: payload, headers: { 'Authorization': user.token }
+      end
+
+      it 'succeeds' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'matches the projects/project schema' do
+        expect(response).to match_response_schema('projects/project')
+      end
+
+      it 'saves due_at' do
+        expect(project.reload.due_at).to eq(DateTime.new(2017, 1, 20, 14))
+      end
+
+      it 'sets started_at to now' do
+        expect(project.reload.started_at).to eq(DateTime.new(2017))
+      end
+
+      it 'returns the updated project' do
+        project = JSON.parse(response.body)
+        expect(project['dueAt']).to eq(1484920800)
+        expect(project['startedAt']).to eq(1483228800)
+      end
+
+    end
+
+    context 'with missing attribute' do
+      before do
+        post "/api/projects/#{ project.id }/start", params: { project: {} }, headers: { 'Authorization': user.token }
+      end
+
+      it 'fails' do
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'matches the error schema' do
+        expect(response).to match_response_schema('error')
+      end
+
+      it 'returns an error message' do
+        error = JSON.parse(response.body)
+        expect(error['message']).to match(/param is missing or the value is empty/)
+      end
+    end
+
+    context 'with already started project' do
+      before do
+        project.start_now! 15.days.from_now
+        post "/api/projects/#{ project.id }/start", params: payload, headers: { 'Authorization': user.token }
+      end
+
+      it 'fails' do
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'matches the error schema' do
+        expect(response).to match_response_schema('error')
+      end
+
+      it 'returns an error message' do
+        error = JSON.parse(response.body)
+        expect(error['message']).to match(/Project has already been started/)
+      end
+    end
+
+    context 'with already 3 in_progress projects' do
+      before do
+        create_list :project, 3, :in_progress, user: user
+        post "/api/projects/#{ project.id }/start", params: payload, headers: { 'Authorization': user.token }
+      end
+
+      it 'fails' do
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'matches the error schema' do
+        expect(response).to match_response_schema('error')
+      end
+
+      it 'returns an error message' do
+        error = JSON.parse(response.body)
+        expect(error['message']).to match(/User cannot have more than/)
+      end
+    end
+
+    context 'with invalid due_at' do
+      before do
+        payload[:project][:due_at] = DateTime.new(2016, 12, 31).to_i
+        post "/api/projects/#{ project.id }/start", params: payload, headers: { 'Authorization': user.token }
+      end
+
+      it 'fails' do
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'matches the error schema' do
+        expect(response).to match_response_schema('error')
+      end
+
+      it 'returns an error message' do
+        error = JSON.parse(response.body)
+        expect(error['message']).to match(/Due at cannot be set/)
+      end
+    end
+
+    context 'when authenticated with another user' do
+      let(:other_user) { create :user }
+
+      before do
+        post "/api/projects/#{ project.id }/start", params: payload, headers: { 'Authorization': other_user.token }
+      end
+
+      it 'fails' do
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'matches the error schema' do
+        expect(response).to match_response_schema('error')
+      end
+
+      it 'returns an error message' do
+        error = JSON.parse(response.body)
+        expect(error['message']).to match(/Project cannot be found/)
+      end
+    end
+  end
+
 end

--- a/spec/requests/api/users_request_spec.rb
+++ b/spec/requests/api/users_request_spec.rb
@@ -297,8 +297,16 @@ RSpec.describe Api::UsersController, type: :request do
 
     context 'with valid token' do
       before do
-        create :project, user: user, name: 'my-project'
+        Timecop.freeze DateTime.new(2017)
+        create :project, :in_progress, user: user,
+                                       name: 'my-project',
+                                       started_at: 15.days.ago,
+                                       due_at: 15.days.from_now
         get '/api/users/me', headers: { 'Authorization': user.token }
+      end
+
+      after do
+        Timecop.return
       end
 
       it 'succeeds' do
@@ -319,6 +327,8 @@ RSpec.describe Api::UsersController, type: :request do
         expect(projects.length).to eq(1)
         expect(projects[0]['name']).to eq('my-project')
         expect(projects[0]['userId']).to eq(user.id)
+        expect(projects[0]['startedAt']).to eq(15.days.ago.to_i)
+        expect(projects[0]['dueAt']).to eq(15.days.from_now.to_i)
       end
     end
 

--- a/spec/support/api/schemas/projects/project.json
+++ b/spec/support/api/schemas/projects/project.json
@@ -1,13 +1,14 @@
 {
   "type": "object",
-  "required": ["id", "name", "userId"],
+  "required": ["id", "name", "userId", "isInProgress"],
   "properties": {
     "id": { "type": "integer" },
     "name": { "type": "string" },
     "userId": { "type": "integer" },
     "description": { "type": "string" },
     "startedAt": { "type": "integer" },
-    "dueAt": { "type": "integer" }
+    "dueAt": { "type": "integer" },
+    "isInProgress": { "type": "boolean" }
   },
   "additionalProperties": false
 }

--- a/spec/support/api/schemas/projects/project.json
+++ b/spec/support/api/schemas/projects/project.json
@@ -5,7 +5,9 @@
     "id": { "type": "integer" },
     "name": { "type": "string" },
     "userId": { "type": "integer" },
-    "description": { "type": "string" }
+    "description": { "type": "string" },
+    "startedAt": { "type": "integer" },
+    "dueAt": { "type": "integer" }
   },
   "additionalProperties": false
 }


### PR DESCRIPTION
Fix #5

- [x] add started_at
- [x] add due_at to Projects (validate not before started_at)
- [x] validate there is no more than 3 projects per user with a started_at attribute present and due_at in the future
- [x] return those information in projects
- [x] add API endpoint to start a project, initialize started_at with DateTime.now
- [x] do not start already started projects
- [x] add a link on Project show page to start it (hide it when started)
- [x] provide a DateField component
- [x] improve ProjectEditForm to show a due_at field
- [x] forbid updated due_at if not started
- [x] present started projects differently on dashboard

tech considerations: dates should be stored in UTC