### PR TITLE
fix: #120 Revert #113 (send to backlog feature)

### DIFF
--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -57,9 +57,7 @@ private
   end
 
   def update_task_params
-    parameters = fetch_resource_params(:task, [], [:label, :due_at])
-    parameters[:due_at] = parameters[:due_at].to_datetime if parameters[:due_at].is_a? Integer
-    parameters
+    fetch_resource_params(:task, [], [:label])
   end
 
 end

--- a/client/src/api/tasks.js
+++ b/client/src/api/tasks.js
@@ -9,8 +9,8 @@ export default {
     return post('/api/tasks', { label, dueAt })
   },
 
-  update (task, payload) {
-    return patch(`/api/tasks/${task.id}`, payload)
+  update (task, label) {
+    return patch(`/api/tasks/${task.id}`, { label })
   },
 
   finish (task) {

--- a/client/src/components/tasks/TaskItem.vue
+++ b/client/src/components/tasks/TaskItem.vue
@@ -40,7 +40,6 @@
         <template slot="menu">
           <popover-item :action="startEditMode">{{ $t('tasks.edit') }}</popover-item>
           <popover-item :action="confirmAbandon">{{ $t('tasks.abandon') }}</popover-item>
-          <popover-item v-if="!task.isBacklogged" :action="sendToBacklog">{{ $t('tasks.sendToBacklog') }}</popover-item>
         </template>
       </popover>
 
@@ -120,14 +119,6 @@
         if (window.confirm(this.$t('tasks.confirmAbandon'))) {
           this.$store.dispatch('tasks/abandon', { task })
         }
-      },
-
-      sendToBacklog () {
-        const { task } = this
-        this.$store.dispatch('tasks/update', {
-          task,
-          dueAt: null,
-        })
       },
     },
 

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -225,6 +225,5 @@ export default {
     plan: 'Plan for today',
     replan: 'Replan for today',
     restarted: 'You’ve restarted this task once | You’ve restarted this task {count} times, what about splitting or renaming it so it would be easier to achieve?',
-    sendToBacklog: 'Send to backlog',
   },
 }

--- a/client/src/store/modules/tasks.js
+++ b/client/src/store/modules/tasks.js
@@ -106,9 +106,8 @@ const actions = {
       })
   },
 
-  update ({ commit }, { task, label, dueAt }) {
-    const payload = { label, dueAt }
-    return tasksApi.update(task, payload)
+  update ({ commit }, { task, label }) {
+    return tasksApi.update(task, label)
                    .then((data) => commit('set', data))
   },
 

--- a/spec/requests/api/tasks_request_spec.rb
+++ b/spec/requests/api/tasks_request_spec.rb
@@ -103,11 +103,8 @@ RSpec.describe Api::TasksController, type: :request do
 
   describe 'PATCH #update' do
     let(:token) { user.token }
-    let(:payload) { {
-      label: 'A new label for a task',
-      due_at: nil,
-    } }
-    let(:task) { create :task, label: 'My task', due_at: DateTime.new(2017), user: user }
+    let(:payload) { { label: 'A new label for a task' } }
+    let(:task) { create :task, label: 'My task', user: user }
 
     subject! { patch "/api/tasks/#{ task.id }", params: { task: payload }, headers: { 'Authorization': token }, as: :json }
 
@@ -122,7 +119,6 @@ RSpec.describe Api::TasksController, type: :request do
 
       it 'saves the new task' do
         expect(task.reload.label).to eq('A new label for a task')
-        expect(task.reload.due_at).to be nil
       end
     end
 


### PR DESCRIPTION
Since pending tasks go directly in the backlog, there is no need of this
buggy feature.

Fix #120 